### PR TITLE
Improved message filtering

### DIFF
--- a/examples/sibs/sibs.cpp
+++ b/examples/sibs/sibs.cpp
@@ -7,7 +7,7 @@ using std::cerr;
 
 int main(int argc, char ** argv) {
     try {
-        ict::spec_server ss("icd.xddl");
+        ict::spec_server ss;
 
         ict::command line("sibs", 
             "Example to parse a sib message containing another.", 
@@ -18,12 +18,13 @@ int main(int argc, char ** argv) {
 
         line.parse(argc, argv);
 
-        auto msg = ict::parse(ss, "220008342E1F7F61BA04C697D176821A7A9F4EA20663F3");
+        auto start = ict::get_record(ss, "icd.xddl");
+        auto msg = ict::parse(start, "220008342E1F7F61BA04C697D176821A7A9F4EA20663F3");
 
         // display sib message
         cout << ict::to_text(msg) << '\n';
 
-        // grab the inner sib
+        // grab the inner sib. The '//' means it doesn't have to be a direct child of msg.root()
         auto c = ict::find(msg.root(), "//SIB-Data-variable");
         if (c==msg.end()) IT_THROW("can't find SIB-Data-variable");
 
@@ -32,11 +33,11 @@ int main(int argc, char ** argv) {
 
         // now parse the inner sib as a SysInfoType19
         // We first get the record we are interested from the spec, and then use it to parse.
-        auto start = ict::get_record(ss, "3GPP/TS-25.331.xddl#SysInfoType19");
+        start = ict::get_record(ss, "3GPP/TS-25.331.xddl#SysInfoType19");
         auto inner = ict::parse(start, c->bits);
 
         // display inner sib
-        cout << ict::to_text(inner);
+        cout << ict::to_text(inner, "nlvsFL");
     }
 
     catch (std::exception & e) {

--- a/include/ict/command.h
+++ b/include/ict/command.h
@@ -17,14 +17,14 @@ class Option
     public:
 
     Option(std::string name, char short_opt, std::string desc, 
-        std::function<void()> action = [&](){ } ) : 
+        std::function<void()> action = [](){ } ) : 
         name(name), short_opt(short_opt), desc(desc), 
         binary_action(action), flag(true), present(false)
     {
     }
 
     Option(std::string name, char short_opt, std::string desc, std::string def, 
-        std::function<void(std::string val)> action = [&](std::string){ }
+        std::function<void(std::string val)> action = [](std::string){ }
         ):
         name(name), short_opt(short_opt), desc(desc), default_value(def), action(action), 
         flag(false), present(false)

--- a/include/ict/multivector.h
+++ b/include/ict/multivector.h
@@ -56,7 +56,7 @@ struct cursor_base : public std::iterator<std::bidirectional_iterator_tag, Value
 
     // constructors
     cursor_base() : v(nullptr), it_(nullptr) {}
-    cursor_base(const ascending_cursor_reference b) : it_(b.it_) {
+    cursor_base(ascending_cursor_reference b) : it_(b.it_) {
         v = &b.it_->parent_item()->nodes_;
     }
     cursor_base(const cursor_base<ValueType, false>& b) : v(b.v), it_(b.it_) {}
@@ -188,7 +188,7 @@ struct ascending_cursor_base : public std::iterator<std::forward_iterator_tag, V
 
     // constructors
     ascending_cursor_base() {}
-    ascending_cursor_base(const cursor_reference b) : it_(b.it_) {}
+    ascending_cursor_base(cursor_reference b) : it_(b.it_) {}
     ascending_cursor_base(const ascending_cursor_base<ValueType, false>& b) : it_(b.it_) {}
     ascending_cursor_base(const item_pointer it) : it_{it} {}
 
@@ -719,6 +719,7 @@ std::string to_debug_text(const multivector<T> & tree) {
     typedef typename multivector<T>::const_cursor cursor_type;
     std::ostringstream ss;
     auto r = tree.root();
+    //to_debug_text(ss, *r);
     ss << *r << " " << r.item_ref().parent << '\n';
     recurse(r, 
         [&](cursor_type self, cursor_type, int level) {
@@ -925,9 +926,11 @@ inline typename Cursor::linear_type linear_end(Cursor parent) {
     return parent.end();
 }
 
+#if 0 // this may not be a good idea
 template <typename T>
 inline std::ostream & operator<<(std::ostream & ss, const multivector<T> & a) {
     ss << to_text(a);
     return ss;
 }
+#endif
 }

--- a/include/ict/netvar.h
+++ b/include/ict/netvar.h
@@ -10,6 +10,11 @@ template <class T> class netvar {
     typedef unsigned char * iterator;
     typedef const iterator const_iterator;
 
+    template <typename InputIter> 
+    netvar(const char * first) { // presume big-endian to start with
+        std::copy(first, first + data.size(), data.begin());
+    }
+
     netvar(T number = 0) {
         auto first = (char *) &number;
         std::reverse_copy(first, first + data.size(), data.begin());
@@ -69,15 +74,6 @@ template <class T> class netvar {
 
     /** Conversion */
     void encode(T number) { *this = number; }
-
-#if 0
-    static T swap(T number) {
-        T value;
-        auto first = (char *) &number;
-        std::reverse_copy(first, first + sizeof(T), (char *) &value);
-        return value;
-    }
-#endif
 
     std::array<unsigned char, sizeof(T)> data;
 };

--- a/include/ict/spec_server.h
+++ b/include/ict/spec_server.h
@@ -83,7 +83,7 @@ public:
     { return doms.empty(); }
 
     friend std::ostream& operator<<(std::ostream &os, const spec_server & s) {
-        for (const auto & d : s.doms) os << d.ast;
+        for (const auto & d : s.doms) os << ict::to_text(d.ast);
         return os;
     }
 

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -27,10 +27,10 @@ const node_info_list node_info = {
 
     { "root", node_info_type::is_nil }, // not sure about this
     
-    { "extra", node_info_type::is_terminal, [&](std::ostream& os, message::cursor n) { 
+    { "extra", node_info_type::is_terminal, [](std::ostream& os, message::const_cursor n) { 
         os << "<extra" << attr("length", n->bits.bit_size()) << attr("data",to_string(n->bits)) << ">"; } },
 
-    { "field", node_info_type::is_terminal, [&](std::ostream& os, message::cursor n) { 
+    { "field", node_info_type::is_terminal, [](std::ostream& os, message::const_cursor n) { 
         if (auto f = get_ptr<field>(n->elem->v)) {
             os << "<field" << attr("name", n->name()) << attr("length", n->bits.bit_size()) <<  
                 attr("data", to_string(n->bits));
@@ -50,122 +50,135 @@ const node_info_list node_info = {
         IT_PANIC("conversion to xml panic error");
     }},
 
-    { "float", node_info_type::is_terminal, [&](std::ostream& os, message::cursor n) { 
+    { "float", node_info_type::is_terminal, [](std::ostream& os, message::const_cursor n) { 
         os << "<float" << attr("name", n->name()) << attr("data", n->bits) << ">";
         description_xml(os, n);
     }},
 
-    { "incomplete", node_info_type::is_terminal, [&](std::ostream& os, message::cursor n) { 
+    { "incomplete", node_info_type::is_terminal, [](std::ostream& os, message::const_cursor n) { 
         os << "<incomplete" << attr("name", n->name()) << attr("value", n->value()) << ">";
     }},
 
-    { "message", node_info_type::is_parent, [&](std::ostream& os, message::cursor n) { 
+    { "message", node_info_type::is_parent, [](std::ostream& os, message::const_cursor n) { 
         os << "<message" << attr("docref", n->file()) << ">";
     }},
     
-    { "record", node_info_type::is_parent, [&](std::ostream& os, message::cursor n) { 
+    { "record", node_info_type::is_parent, [](std::ostream& os, message::const_cursor n) { 
         os << "<record" << attr("name", n->name()) << ">";
     }},
     
-    { "repeat", node_info_type::is_parent, [&](std::ostream& os, message::cursor n) { 
+    { "repeat", node_info_type::is_parent, [](std::ostream& os, message::const_cursor n) { 
         os << "<repeat" << attr("name", n->name()) << ">";
     }},
 
-    { "prop", node_info_type::is_property, [&](std::ostream& os, message::cursor n) { 
+    // repeat record
+    { "record", node_info_type::is_parent, [](std::ostream& os, message::const_cursor n) { 
+        os << "<record" << attr("name", n->name()) << ">";
+    }},
+
+    { "prop", node_info_type::is_property, [](std::ostream& os, message::const_cursor n) { 
         os << "<prop" << attr("name", n->name()) << attr("value", n->value()) << ">";
         description_xml(os, n);
     }},
     
-    { "setprop", node_info_type::is_property, [&](std::ostream& os, message::cursor n) { 
+    { "setprop", node_info_type::is_property, [](std::ostream& os, message::const_cursor n) { 
         os << "<setprop" << attr("name", n->name()) << attr("value", n->value()) << ">";
         description_xml(os, n);
     }},
 
-    { "global", node_info_type::is_property, [&](std::ostream& os, message::cursor n) { 
-        os << "<global" << attr("name", n->name())  << ">";
-    }},
-    
-    
-    { "peek", node_info_type::is_property, [&](std::ostream& os, message::cursor n) { 
+    { "peek", node_info_type::is_property, [](std::ostream& os, message::const_cursor n) { 
         os << "<peek" << attr("name", n->name()) << attr("value", n->value()) << ">";
     }},
 
-    { "error", node_info_type::is_property, [&](std::ostream& os, message::cursor n) { 
+    { "error", node_info_type::is_property, [](std::ostream& os, message::const_cursor n) { 
         os << "<error" << attr("desc", n->desc) << ">";
     }},
 };
 
 // convert a message cursor to xml
-void to_xml(std::ostringstream &os, message::cursor c) {
-    node_info[c->type].start_tag(os, c);
-    if (!c.empty()) for (auto n = c.begin(); n!= c.end(); ++n) to_xml(os, n);
-    os << "</" << node_info[c->type].name << ">";
+namespace util {
+    template <typename Cursor, typename Filter>
+    void to_xml(std::ostringstream &os, Cursor c, Filter filter) {
+        node_info[c->type].start_tag(os, c);
+        if (!c.empty() && filter(c)) for (auto n = c.begin(); n!= c.end(); ++n) to_xml(os, n, filter);
+        os << "</" << node_info[c->type].name << ">";
+    }
+
+    template <typename Cursor, typename Filter>
+    std::string to_xml(Cursor c, Filter filter) {
+        std::ostringstream os;
+        os << "<message>";
+        if (!c.empty()) for (auto n = c.begin(); n!= c.end(); ++n) util::to_xml(os, n, filter);
+        os << "</message>";
+        return os.str();
+    }
 }
 
-std::string to_xml(message::cursor c) {
-    std::ostringstream os;
-    if (!c.empty()) for (auto n = c.begin(); n!= c.end(); ++n) to_xml(os, n);
-    return os.str();
+std::string to_xml(const message & m, 
+    std::function<bool(message::const_cursor c)> filter) {
+    return util::to_xml(m.root(), filter);
 }
-
 
 // get the file name of a message cursor
 
-void node_text(ht::text_rows & rows, message::const_cursor parent, std::vector<ht::heading> & vh, int level = 0) {
+template <typename Filter>
+void node_text(ht::text_rows & rows, message::const_cursor parent, std::vector<ht::heading> & vh, Filter & filter, int level = 0) {
     ht::text_row row;
 
     auto first = parent.begin();  // for calculating row
     for (auto n = parent.begin(); n != parent.end(); ++n) {
-        for (auto & h : vh) {
-            std::string curr = "";
-            switch (h.type) {
-                case ht::mnemonic : curr = n->mnemonic(); break;
-                case ht::name : 
-                {
-                    curr = ict::spaces(level * 2);
-                    curr = curr + n->name();
+        if (filter(n)) {
+            for (auto & h : vh) {
+                std::string curr = "";
+                switch (h.type) {
+                    case ht::mnemonic : curr = n->mnemonic(); break;
+                    case ht::name : 
+                    {
+                        curr = ict::spaces(level * 2);
+                        curr = curr + n->name();
 
-                    break;
-                }
-                case ht::length:
-                    if (n->consumes()) curr = ict::to_string(n->length());
-                    break;
-                case ht::value:
-                    if (n->is_terminal()) {
-                        if (n->length() > 64) curr="***";
-                        else curr = ict::to_string(n->value());
+                        break;
                     }
-                    break;
-                case ht::hex: 
-                    if (n->consumes()) {
-                        curr = ict::to_string(n->bits);
-                        if (n->length() > 64) {
-                            curr.resize(64 / 4);
-                            curr += "...";
+                    case ht::length:
+                        if (n->consumes()) curr = ict::to_string(n->length());
+                        break;
+                    case ht::value:
+                        if (n->is_terminal()) {
+                            if (n->length() > 64) curr="***";
+                            else curr = ict::to_string(n->value());
                         }
+                        break;
+                    case ht::hex: 
+                        if (n->consumes()) {
+                            curr = ict::to_string(n->bits);
+                            if (n->length() > 64) {
+                                curr.resize(64 / 4);
+                                curr += "...";
+                            }
+                        }
+                        break;
+                    case ht::line: curr = ict::to_string(n->line()); break;
+                    case ht::file: curr = n->file(); break;
+                    case ht::row: curr = ict::to_string(n - first); break;
+                    case ht::description: 
+                    {
+                        curr = description(n); 
+                        break;
                     }
-                    break;
-                case ht::line: curr = ict::to_string(n->line()); break;
-                case ht::file: curr = n->file(); break;
-                case ht::row: curr = ict::to_string(n - first); break;
-                case ht::description: 
-                {
-                    curr = description(n); 
-                    break;
+                    default: {}
                 }
-                default: {}
+                h.width = std::max(h.width, curr.size());
+                row.push_back(curr);
             }
-            h.width = std::max(h.width, curr.size());
-            row.push_back(curr);
+            rows.push_back(row);
+            row.clear();
+            if (!n.empty()) node_text(rows, n, vh, filter, level + 1);
         }
-        rows.push_back(row);
-        row.clear();
-        if (!n.empty()) node_text(rows, n, vh, level + 1);
     }
 }
 
-#if 1
-std::string to_text(const message & m, const std::string & format) {
+std::string to_text(const message & m, const std::string & format, 
+    std::function<bool(message::const_cursor c)> filter) {
     auto fsv = format;
     std::vector<ht::heading> vh;
 
@@ -196,7 +209,7 @@ std::string to_text(const message & m, const std::string & format) {
 
     rows.push_back(header);
 
-    node_text(rows, m.root(), vh);
+    node_text(rows, m.root(), vh, filter);
 
     std::ostringstream os;
     for (auto i = vh.begin(); i != vh.end()-1; ++i) ++i->width;
@@ -208,70 +221,6 @@ std::string to_text(const message & m, const std::string & format) {
     }
 
     return os.str();
-}
-#else
-std::string message::text(std::string const & fstring, bool skip_header) const {
-    auto fsv = fstring;
-    std::vector<ht::heading> vh;
-
-    ht::text_row header;
-    for (auto v : fsv) {
-        ht::heading h;
-        switch (v) {
-            case 'h' : h.type = ht::hex; break;
-            case 'l' : h.type = ht::length; break;
-            case 'L' : h.type = ht::line; break;
-            case 'F' : h.type = ht::file; break;
-            case 'm' : h.type = ht::mnemonic; break;
-            case 'n' : h.type = ht::name; break;
-            case 's' : h.type = ht::description; break;
-            case 'v' : h.type = ht::value; break;
-            case 'r' : h.type = ht::row; break;
-
-            default:
-                IT_PANIC("unrecognized format: " << v << " in format string " << fsv);
-        }
-        std::string heading_name{ht::to_name(h.type)};
-        h.width = heading_name.size() + 1;
-        vh.push_back(h);
-        header.push_back(heading_name);
-    }
-
-    ht::text_rows rows;
-
-    if (!skip_header) rows.push_back(header);
-
-    node_text(rows, root(), vh);
-
-    std::ostringstream os;
-    for (auto i = vh.begin(); i != vh.end()-1; ++i) ++i->width;
-    for (auto const & row : rows) {
-        for (unsigned i =0; i< vh.size(); ++i) {
-            os << row[i] << ict::spaces(vh[i].width - row[i].size());
-        }
-        os << "\n";
-    }
-
-    return os.str();
-}
-#endif
-message parse(spec::cursor start, ibitstream & bs) {
-    message m;
-    m.root().emplace_back(node::global, start);
-    parse(start, m.root(), bs);
-    return m;
-}
-
-message parse(spec::cursor start, const bitstring & bits) {
-    ibitstream bs(bits);
-    return parse(start, bs);
-}
-
-
-message parse(spec_server & spec, const bitstring & bits) {
-    if (spec.empty()) IT_THROW("empty spec");
-    auto start = find(spec.base().ast.root(), "xddl", tag_of);
-    return parse(start, bits);
 }
 
 } // namespace

--- a/src/xddl.xspx
+++ b/src/xddl.xspx
@@ -43,7 +43,7 @@
         <child>oob</child>
         <child>pad</child>
         <child>peek</child>
-        <child>per</child>
+        <child>enc</child>
         <child>prop</child>
         <child>record</child>
         <child>repeat</child>
@@ -65,7 +65,6 @@
             std::map&lt;ict::url, xddl_cursor&gt; type_map;
             class spec_server * owner = 0;
             int in_oob = 0;
-            //int in_per = 0;
         </code>
     </parser>
 
@@ -90,6 +89,10 @@
         virtual ict::url vhref() const final { return href; };
     </code>
 
+    <code id="is_visible">
+        virtual bool is_visible() const final { return visible; };
+    </code>
+
     <code id="var_type">
         virtual void vto_string(std::ostream &amp;) const { return; }; 
         virtual void vparse(xddl_cursor, msg_cursor, ibitstream &amp;) const;
@@ -99,6 +102,7 @@
         virtual void vset_ref(xddl_cursor) {};
         virtual std::pair&lt;bool, xddl_cursor&gt; vget_ref() { return std::make_pair(false, xddl_cursor()); };
         virtual ict::url vhref() const { return ict::url(); }
+        virtual bool is_visible() const { return true; }
         virtual ~var_type() {};
     </code>
 
@@ -116,7 +120,7 @@
             dependent_flag,
             global_flag,
             oob_flag,
-            per_flag
+            enc_flag
         };
         std::bitset&lt;4&gt; flags;
         </public>
@@ -209,7 +213,7 @@
         <code href="vparse"/>
     </element>
 
-    <element tag="per" end_handler="true">
+    <element tag="enc" end_handler="true">
         <child>fragment</child>
         <child>type</child>
         <child>start</child>
@@ -232,6 +236,7 @@
         <code href="venum_string"/>
         <code href="vhref"/>
         <code href="mutable_ref"/>
+        <code href="is_visible"/>
     </element>
 
     <!--

--- a/tools/asnx/asnast.cpp
+++ b/tools/asnx/asnast.cpp
@@ -74,6 +74,7 @@ string ElementTypeList::optional_bitmap(std::vector<Type *> const & item_list) c
     if (optional.empty()) return std::string();
 
     std::ostringstream xml;
+    xml << "<enc>";
     xml << "<record name=''option''>";
     int i = 0;
     for (it = optional.begin(); it!=optional.end(); ++it, ++i) {
@@ -81,6 +82,7 @@ string ElementTypeList::optional_bitmap(std::vector<Type *> const & item_list) c
     }
 
     xml << "</record>";
+    xml << "</enc>";
     return xml.str();
     
 }
@@ -88,6 +90,7 @@ string ElementTypeList::optional_bitmap(std::vector<Type *> const & item_list) c
 string ElementTypeList::extension_bitmap(std::vector<Type *> const & item_list) const
 {
     std::ostringstream xml;
+    xml << "<enc>";
     xml << "<field name=''ext-cnt'' length=''7'' bias=''1''/>";
     xml << "<record name=''option'' length=''{ext-cnt}''>";
     int i = 0;
@@ -96,6 +99,7 @@ string ElementTypeList::extension_bitmap(std::vector<Type *> const & item_list) 
         xml << "<field name=''" << (*it)->name() << "'' length=''1'' type=''#opt''/>";
     }
     xml << "</record>";
+    xml << "</enc>";
     return xml.str();
     
 }
@@ -104,7 +108,7 @@ string ElementTypeList::instance() const
 {
     ostringstream xml;
 
-    if (extension) xml << "<per><field name=''ext'' length=''1''/></per>";
+    if (extension) xml << "<enc><field name=''ext'' length=''1''/></enc>";
 
     xml << optional_bitmap(items);
 
@@ -329,7 +333,7 @@ string EnumeratedType::base_enum_field(Name * id, vector<NamedNumber *> items) c
 string ext_enum_field(Name * id, vector<NamedNumber *> items)
 {
     ostringstream os;
-    os << "<per><field name=''b0'' length=''1''/></per>"
+    os << "<enc><field name=''b0'' length=''1''/></enc>"
       "<field name=''" << id->name() << "'' length=''b0 ? 15 : 6''>";
 
     vector<NamedNumber *>::iterator it;
@@ -348,7 +352,7 @@ string EnumeratedType::instance(Name * id) const
 
     if (number_list->extension)
     {
-        os << "<per><field name=''ext'' length=''1''/></per>";
+        os << "<enc><field name=''ext'' length=''1''/></enc>";
         if (number_list->items.size() > 1)
         {
             os << "<switch expr=''ext''>"
@@ -584,10 +588,10 @@ string Subtype::declaration(Name * id) const {
 
 string SubtypeSpec::size_field() {
     ostringstream os;
-    os << "<per><field name=''count'' length=''" << size_str() << "''";
+    os << "<enc><field name=''count'' length=''" << size_str() << "''";
     string l = lower()->qstr();
     if (l != "0" && is_range()) os << " bias=''" << l << "''";
-    os << "/></per>";
+    os << "/></enc>";
     return os.str();
 }
 

--- a/tools/asnx/asnast.h
+++ b/tools/asnx/asnast.h
@@ -30,8 +30,8 @@ inline std::string var_length()
 {
     std::ostringstream os;
     os << 
-      "<per><field name=''b0'' length=''1''/>"
-      "<field name=''length'' length=''b0 ? 15 : 7''/></per>";
+      "<enc><field name=''b0'' length=''1''/>"
+      "<field name=''length'' length=''b0 ? 15 : 7''/></enc>";
 
     return os.str();
 }
@@ -243,7 +243,7 @@ class AlternativeTypeList : public ast {
         int range = ict::required_bits(0, items.size() - 1);
 
         std::ostringstream xml;
-        xml << "<per><field name=''choice'' length=''" << range << "''>";
+        xml << "<enc><field name=''choice'' length=''" << range << "''>";
         int i=0;
         std::vector<Type *>::const_iterator it;
 
@@ -251,7 +251,7 @@ class AlternativeTypeList : public ast {
         {
             xml << "<item key=''" << i++ << "'' value=''" << (*it)->name() << "''/>";
         }
-        xml << "</field></per>";
+        xml << "</field></enc>";
         
         // now create the switch statement
         xml << "<switch expr=''choice''>";
@@ -270,7 +270,7 @@ class AlternativeTypeList : public ast {
     std::string ext_choice() const
     {
         std::ostringstream xml;
-        xml << "<per><field name=''b0'' length=''1''/>"
+        xml << "<enc><field name=''b0'' length=''1''/>"
         "<field name=''choice'' length=''b0 ? 15 : 6''>";
         int i=0;
         std::vector<Type *>::const_iterator it;
@@ -279,7 +279,7 @@ class AlternativeTypeList : public ast {
         {
             xml << "<item key=''" << i++ << "'' value=''" << (*it)->name() << "''/>";
         }
-        xml << "</field></per>";
+        xml << "</field></enc>";
         
         // length of the extension
         xml << var_length();
@@ -315,7 +315,7 @@ class AlternativeTypeList : public ast {
 		// add the extension bit if it exists
             if (extension)
             {
-                xml << "<per><field name=''ext'' length=''1''/></per>"
+                xml << "<enc><field name=''ext'' length=''1''/></enc>"
                 "<switch expr=''ext''>"
                   "<case value=''0''>" << 
                      root_choice() <<

--- a/tools/idm/idm.cpp
+++ b/tools/idm/idm.cpp
@@ -2,36 +2,45 @@
 //-- See https://github.com/intrig/xenon for license.
 #include <ict/xenon.h>
 #include <ict/command.h>
+#include <ict/xddl_code.h>
 
 using std::cout;
 using std::cerr;
 using std::endl;
 
 struct command_flags {
-    bool output_xml = false;
-    bool pretty_xml = true;
+    bool flat_xml = false;
+    bool pretty_xml = false;
+    bool debug_print = false;
     bool output_dom = false;
+
+    bool encoding = false;
+    bool properties = false;
+    bool show_extra = false;
     std::string format = "nlvhs";
 };
 
 void processXddlFile(ict::command const & line, command_flags const & flags);
 
 int main(int argc, char **argv) {
+    using ict::command;
+    using ict::option;
     try {
         command_flags flags;
 
-        ict::command line("lt", "Linesight from the cli", 
-            "lt [options] xddl_file [message]...\n"
-            "lt [options] pcap_file");
+        command line("idm", "A cli message decoder.", 
+            "idm [options] xddl_file [message]...\n");
 
-        line.add(ict::Option("xml", 'x', "Display message(s) in XML", [&]{ flags.output_xml = true; } ));
-        line.add(ict::Option("flat-xml", 'f', "Display message(s) in flat XML", 
-            [&]{ flags.output_xml = true; flags.pretty_xml = false;} ));
-        line.add(ict::Option("format", 'F', "message columns", flags.format, 
-            [&](const std::string & v){ flags.format = v; } ));
-        line.add(ict::Option("dom", 'd', "Display xddl dom", [&]{ flags.output_dom = true; } ));
+        line.add(option("encoding", 'e', "Display encoding fields", [&]{ flags.encoding = true; } ));
+        line.add(option("properties", 'p', "Display properties", [&]{ flags.properties = true; } ));
+        line.add(option("xml", 'x', "Display message(s) in XML", [&]{ flags.pretty_xml = true; } ));
+        line.add(option("flat-xml", 'f', "Display message(s) in flat XML", [&]{ flags.flat_xml = true; } ));
+        line.add(option("location", 'L', "show xddl source location", [&]{ flags.format += "FL"; } ));
+        line.add(option("dom", 'd', "Display xddl dom", [&]{ flags.output_dom = true; } ));
+        line.add(option("debug", 'D', "Display message(s) in debug gibberish", [&]{ flags.debug_print = true; } ));
+        line.add(option("extra", 'E', "Display extra bits", [&]{ flags.show_extra = true; } ));
 
-        line.add_note("message : an ASCII hex or binary message string: e.g., 010304 or @11011011");
+        line.add_note("message : an ASCII hex or binary message string: e.g., A10304 or @11011011");
 
         line.parse(argc, argv);
 
@@ -42,7 +51,7 @@ int main(int argc, char **argv) {
             processXddlFile(line, flags);
         }
 
-        else IT_THROW("unrecognized file: " << filename);
+        else IT_PANIC("unrecognized file: " << filename);
         
 
     } catch (ict::exception & e) {
@@ -62,6 +71,12 @@ void processXddlFile(ict::command const & line, command_flags const & flags) {
         
         ict::bitstring bs; // the message to parse
         std::ostringstream inst_dump;
+
+        auto filter = [&](ict::message::const_cursor c) { 
+            if (!flags.encoding   && c->is_encoding()  ) return false;
+            if (!flags.properties && c->is_prop() && !c->is_visible()) return false;
+            if (!flags.show_extra && c->is_extra()) return false;
+            return true; };
         for (; i != line.targets.end(); ++i) {
             ict::message inst;
             bs = ict::bitstring(i->c_str());
@@ -78,8 +93,16 @@ void processXddlFile(ict::command const & line, command_flags const & flags) {
             }
             else start = d.start();
             inst = ict::parse(start, bs);
-            if (flags.output_xml) inst_dump << ict::to_xml(inst.root());
-            else inst_dump << ict::to_text(inst, flags.format);
+            if (flags.flat_xml) inst_dump << ict::to_xml(inst, filter) << '\n';
+            else if (flags.pretty_xml) {
+                ict::Xml pretty;
+                pretty << ict::to_xml(inst, filter) << "\n";
+                inst_dump << pretty;
+            }
+            else if (flags.debug_print) {
+                inst_dump << ict::to_debug_text(inst, filter) << '\n';
+            }
+            else inst_dump << ict::to_text(inst, flags.format, filter);
 
             cout << inst_dump.str(); 
             inst_dump.str("");
@@ -91,3 +114,6 @@ void processXddlFile(ict::command const & line, command_flags const & flags) {
     }
 }
 
+/* 
+idm icd.xddl C308D1472EEFC299D40000000000060003018C1FAD90001801520040028200005354AAD3DA18D73B9830140A4800
+*/

--- a/unit/xddlunit/per.xddl
+++ b/unit/xddlunit/per.xddl
@@ -3,8 +3,8 @@
 <!-- - See https://github.com/intrig/xenon for license. -->
 <xddl>
   <start>
-    <per>
+    <enc>
       <field name="foo" length="1" default="1"/>
-    </per>
+    </enc>
   </start>
 </xddl>

--- a/xddl/icd.xddl
+++ b/xddl/icd.xddl
@@ -31,6 +31,13 @@
     <prop name="TP_User_Data_Header_Length_prop" value="0"/>
     <prop name="Message_Waiting_Indication_prop" value="0"/>
     <prop name="Message_Coding_prop" value="0"/>
+
+    <!-- UTRA -->
+    <prop name="DTMGPRSMultiSlotClassIncl_prop" value="0"/>
+    <prop name="DTMGPRSMultiSlotClass_prop" value="0"/>
+    <prop name="DTMEGPRSMultiSlotClass_prop" value="0"/>
+    <prop name="DTMEGPRSMultiSlotClassIncl_prop" value="0"/>
+    <prop name="L2PseudoLengthExists_prop" value="0"/>
   </export>
   <oob>
     <!-- This entire icd is out-of-band -->
@@ -119,11 +126,6 @@
       <item key="999" value="UTRA Message"/>
     </type>
     <record name="UTRA" id="3">
-      <prop name="DTMGPRSMultiSlotClassIncl_prop" value="0"/>
-      <prop name="DTMGPRSMultiSlotClass_prop" value="0"/>
-      <prop name="DTMEGPRSMultiSlotClass_prop" value="0"/>
-      <prop name="DTMEGPRSMultiSlotClassIncl_prop" value="0"/>
-      <prop name="L2PseudoLengthExists_prop" value="0"/>
       <setprop name="Name" type="#utra-temp-type" value="999"/>
       <field name="Sublayer" length="8" type="#3-1"/>
       <jump base="Sublayer"/>


### PR DESCRIPTION
Improved message display fliters with idm and added debug output option.  It now filters out encoding fields,
properties, etc.

Added more functions to ict::node.
Added is_visible to ict::node and removed it from ict::element.
Filtering is now also added to xml formatted output.
Changed <per> to <enc> in xddl.
Fixed a bug in timestamp when an invalid tick count was used (found by recombobulator).