### PR TITLE
Improved compile time

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "include/ict"]
 	path = include/ict
-	url = https://github.com/intrig/ict
+	url = https://github.com/wythe/ict

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "include/ict"]
 	path = include/ict
-	url = https://github.com/wythe/ict
+	url = https://github.com/xenon/ict

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,3 @@ mtags:
 	/usr/bin/find . -name '*.c' -o -name '*.cpp' -o -name '*.h' | grep -v "moc_" | grep -v "ui_" | grep -v "/o/"> o/flist && \
 	/usr/local/bin/ctags --file-tags=yes --language-force=C++ -L o/flist
 	@echo tags complete.
-

--- a/README.md
+++ b/README.md
@@ -1,35 +1,94 @@
-# xenon
-The Intrig message decoder.
+#  The Intrig Message Decoder
+* 1 [Introduction ](#1)
+    * 1.1 [Quick Start ](#1.1)
+        * 1.1.1 [Building on Windows ](#1.1.1)
+    * 1.2 [Dependencies ](#1.2)
+        * 1.2.1 [Optional Dependencies ](#1.2.1)
+    * 1.3 [Updating an existing repo to latest ](#1.3)
+* 2 [Using Xenon ](#2)
+* 3 [Licensing ](#3)
 
-## Quick Start
+##<a name="1"/>1 Introduction 
+
+Intrig Xenon provides flexible, powerful and easy to use C++ API for decoding protocol messages.
+
+Originally developed for 3G and 4G programmers and test engineers to decode their complex messages, the xenon decoder
+has evolved into a general purpose open source tool with an ever expanding protocol support base.
+
+And, using XDDL, you can support your own proprietary message formats.
+
+See xenon in action for yourself using the Intrig online decoder: [http://intrig.com/x82da86](intrig.com).
+
+###<a name="1.1"/>1.1 Quick Start 
+
 
     git clone --recursive https://github.com/intrig/xenon.git
     cd xenon
     make 
     make test
 
-## Updating an existing repo to latest
+####<a name="1.1.1"/>1.1.1 Building on Windows 
+
+
+Windows requires the following steps:
+
+1. Install [Github Desktop](https://desktop.github.com)
+
+   Clone the xenon repo.
+
+2. Install [cmake](https://cmake.org/runningcmake/)
+
+   Follow the instructions in the above link to have cmake generate the Visual Studio build files.
+
+3. Microsoft Visual Studio 2015 (or later)
+  
+  Load and build the Visual Studio Solution file located at `xenon/build/Program.sln`.
+
+###<a name="1.2"/>1.2 Dependencies 
+
+
+* cmake
+* C++11 compiler
+* Github desktop (for Windows only)
+
+####<a name="1.2.1"/>1.2.1 Optional Dependencies 
+
+
+Boost dependencies are not required for xenon, but some tests tests will be skipped if boost cannot be found.
+
+* ubuntu: sudo apt-get install libboost-all-dev
+* mac: brew install boost
+* Windows: dunno, I just skip it
+
+Tests can be run with
+
+    make test
+
+###<a name="1.3"/>1.3 Updating an existing repo to latest 
+
 
     git pull
     git submodule update
 
-## Dependencies
+##<a name="2"/>2 Using Xenon 
 
-    cmake
-    C++11 compiler
 
-## Additinal dependencies
+For your application, add the `xenon/include` directory to your include path, and and link with the xenon library found
+in the `xenon/o` directory.
 
-These dependencies are not required for xenon, but are for running some tests.
+See the `xenon/examples' directory for some common uses of the decoder.
 
-    ubuntu: sudo apt-get install libboost-all-dev
-    mac: brew install boost
-    windows: dunno, I just skip it
+Also, the tools directory contains useful examples, such as `idm` and xv.
 
-After building, a static library, xenon, can be found in the o directory.
+##<a name="3"/>3 Licensing 
 
-See the examples directory for some common uses of the decoder.
 
-Also, the tools directory contains examples, such as idm and xv.
+Choose from multiple licensing for Xenon:
 
-For your application, you just need the contents of the include directory and link with the xenon library.
+* **GPL** for open source and internal tools
+* **Intrig Commercial License** for distributing with your own software.  This version comes with unlimited support.
+  Contact support@intrig.com for more on commercial licensing.
+
+Additionally, [The Intrig C++ Toolkit](https://github.com/intrig/ict), a set of powerful C++ types and function that
+xenon is built upon, is available under the permissive MIT license.  Check it out!
+

--- a/include/xenon/message.h
+++ b/include/xenon/message.h
@@ -27,35 +27,10 @@ inline int64_t bit_size(message::cursor parent) {
 
 // Create a global prop and set it equal to the given bitstring, or the default given by the spec.
 // Precondition: The global does not yet exist.
-inline message::cursor create_global(spec::cursor xddl_root, message::cursor globs, const std::string & name, 
-    bitstring bits = bitstring()) {
-    static auto prop_path = path("export/prop");
-    auto root = xddl_root;
-    auto c = find(root, prop_path, tag_of, cmp_name(name));
+message::cursor create_global(spec::cursor xddl_root, message::cursor globs, const std::string & name, 
+    bitstring bits = bitstring());
 
-    if (c == root.end()) { // must be an extern
-        c = find(root, "extern", tag_of, cmp_name(name));
-        if (c == root.end()) IT_PANIC("internal panic looking for " << name  << " in " << xddl_root->parser->file); 
-    }
-
-    if (bits.empty()) {
-        if (auto prop_elem = get_ptr<prop>(c->v)) {
-            if (!prop_elem) IT_PANIC("internal panic");
-            auto v = prop_elem->value.value(leaf(globs));
-            bits = ict::from_integer(v);
-        } 
-    }
-
-    return globs.emplace(node::prop_node, c, bits);
-}
-
-inline message::cursor set_global(spec::cursor self, message::cursor value) {
-    auto globs = ict::get_root(value).begin(); 
-    auto g = find(globs, value->name());
-    if (g == globs.end()) g = create_global(get_root(self).begin(), globs, value->name(), value->bits);
-    else g->bits = value->bits;
-    return g;
-}
+message::cursor set_global(spec::cursor self, message::cursor value);
 
 inline message::cursor set_global(spec::cursor self, message::cursor value, spec::cursor elem) {
     auto g = set_global(self, value);
@@ -64,48 +39,10 @@ inline message::cursor set_global(spec::cursor self, message::cursor value, spec
 }
 
 // load time 
-inline spec::cursor get_variable(const std::string & name, spec::cursor context) {
-    static auto prop_path = path("xddl/export/prop");
-    static auto extern_path = path("xddl/extern");
-    spec::ascending_cursor first(context);
-    while (!first.is_root()) {
-        if (name == first->name()) return first;
-        ++first;
-    }
-    auto root = spec::cursor(first);
-    auto x = find(root, prop_path, tag_of, cmp_name(name));
-    if (x != root.end()) return x;
-
-    // not found, search for <extern>
-    // TODO: remove <extern> and just use global, if 2 globals have different defaults, then undefined
-    // or get rid of global and just use props
-    auto c = find(root, extern_path, tag_of, cmp_name(name));
-    if (c != root.end()) return c;
-    
-    // verify(root);
-    IT_PANIC("cannot find " << name << " starting at " << context->name());
-}
+spec::cursor get_variable(const std::string & name, spec::cursor context);
 
 // parse time
-inline message::cursor get_variable(const std::string & name, message::cursor context) {
-    auto first = rfind(context, name);
-    if (!first.is_root()) return first;
-
-    // first is now pointing at message root
-    auto globs = first.begin();
-    auto g = find(globs, name);
-    if (g == globs.end()) {
-        auto xddl_root = ict::get_root(context->elem).begin();
-        try {
-            g = create_global(xddl_root, globs, name);
-        } catch (std::exception & e) {
-            ict::osstream os;
-            os << e.what() << " [" << context->file() << ":" << context->line() << "]";
-            IT_FATAL(os.str());
-        }
-    }
-    return g;
-}
+message::cursor get_variable(const std::string & name, message::cursor context);
 
 // load time validation
 inline int64_t eval_variable(const std::string &name, spec::cursor context) {
@@ -117,28 +54,7 @@ inline int64_t eval_variable(const std::string &name, spec::cursor context) {
     return 1;
 }
 
-inline int64_t eval_variable_list(const std::string &first, const std::string &second, spec::cursor context) {
-    auto f = get_variable(first, context);
-    auto s = find(f, second);
-    if (s == f.end()) { // second not found, it may be in another spec though (f may be a reclink)
-        // f is a reclink, so get the record it is pointing to.
-        if (auto r = get_ptr<reclink>(f->v)) {
-            auto xddl = rfind(context, "xddl", tag_of);
-            auto c = find(xddl, "record", tag_of, [&](const element &e) {
-                if (auto rec = get_ptr<recdef>(e.v)) {
-                    if (rec->id == r->href) return 1;
-                }
-                return 0;
-            });
-            if (c == xddl.end()) IT_PANIC("cannot find record: " << r->href);
-            s = find(c, second);
-            if (s == c.end()) IT_PANIC("cannot find " << second << " in " << r->href);
-        }
-    }
-    s->flags.set(element::dependent_flag);
-    return 1;
-}
-
+int64_t eval_variable_list(const std::string &first, const std::string &second, spec::cursor context); 
 
 // TODO: move this one to spec.h, otherwise loading a doc is dependent on message.h
 inline int64_t eval_function(const std::string &name, spec::cursor, 
@@ -161,26 +77,8 @@ inline int64_t eval_variable_list(const std::string &first, const std::string &s
     return ict::to_integer<int64_t>(s->bits);
 }
 
-inline int64_t eval_function(const std::string &name, message::cursor context,  
-    const std::vector<ict::expression::param_type> &params) {
-    if (name == "sizeof") {
-        auto c = get_variable(params[0].name, context);
-        return bit_size(c);
-    }
-    else if ((name == "defined")) {
-        if (rfind(context, params[0].name).is_root()) return 0;
-        return 1;
-    }
-
-    else if ((name == "value")) {
-        auto c = rfind(context, params[0].name);
-        if (!c.is_root()) return c->value();
-        IT_WARN("cannot find " << params[0].name);
-        return 0;
-    }
-
-    IT_PANIC("runtime eval_function not implemented for " << name);
-}
+int64_t eval_function(const std::string &name, message::cursor context,  
+    const std::vector<ict::expression::param_type> &params);
 
 template <typename S, typename C>    
 inline void description_xml(S & os, C c) {

--- a/include/xenon/xddl_code.h
+++ b/include/xenon/xddl_code.h
@@ -2,7 +2,6 @@
 //-- Copyright 2016 Intrig
 //-- See https://github.com/intrig/xenon for license.
 #include <xenon/xml_parser_base.h>
-#include <ict/osstream.h>
 
 #include <stack>
 #include <map>
@@ -13,12 +12,11 @@ namespace xenon {
     class XmlText
     {
         public:
-        explicit XmlText(std::string const & s) : content(s) { }
+        XmlText(std::string const & s) : content(s) { }
         std::string content;
     };
 
-    template <typename S>
-    inline S & to_stream(S & os, XmlText const & cd)
+    inline std::ostream & operator<<(std::ostream & os, XmlText const & cd)
     {
         std::string::const_iterator it;
         for (it=cd.content.begin(); it!= cd.content.end(); ++it)
@@ -37,16 +35,6 @@ namespace xenon {
         return os;
     }
 
-    template <typename S>
-    inline S & operator<<(S & os, XmlText const & cd) {
-        return to_stream(os, cd);
-    }
-
-    inline ict::osstream & operator<<(ict::osstream & os, XmlText const & cd) {
-        return to_stream(os, cd);
-    }
-
-
     typedef std::pair<std::string, std::string> attpair;
 
     class XmlAttribute
@@ -57,7 +45,7 @@ namespace xenon {
     };
 
     template <typename S>
-    inline S & to_stream(S & os, XmlAttribute const & cd) {
+    inline S & operator<<(S & os, XmlAttribute const & cd) {
         for (auto it=cd.content.begin(); it!= cd.content.end(); ++it)
         {
             switch (*it)
@@ -72,14 +60,6 @@ namespace xenon {
             }
         }
         return os;
-    }
-    template <typename S>
-    inline S & operator<<(S & os, XmlAttribute const & cd) {
-        return to_stream(os, cd);
-    }
-
-    inline ict::osstream & operator<<(ict::osstream & os, XmlAttribute const & cd) {
-        return to_stream(os, cd);
     }
 
     template <typename Stream>
@@ -171,7 +151,7 @@ namespace xenon {
                 //std::sort(attvec.begin(), attvec.end(), AttCompare());
                 my_sort(attvec);
 
-                ict::osstream os;
+                std::ostringstream os;
 
                 std::vector<attpair>::iterator it;
                 for (it=attvec.begin(); it!=attvec.end(); ++it)
@@ -235,17 +215,10 @@ namespace xenon {
 
         std::string str()
         {
-            ict::osstream ss;
+            std::ostringstream ss;
             str(ss);
             return ss.str();
         }
-
-        template <typename S>
-        void to_stream(S & os) {
-            str(os);
-        }
-
-        
 
         std::string raw()
         {
@@ -390,5 +363,5 @@ public:
         std::stack<std::shared_ptr<XmlElement>> elements;
     };
 
-    using xml_type = Xml<ict::osstream>;
+    using xml_type = Xml<std::ostream>;
 }

--- a/include/xenon/xddl_code.h
+++ b/include/xenon/xddl_code.h
@@ -2,6 +2,7 @@
 //-- Copyright 2016 Intrig
 //-- See https://github.com/intrig/xenon for license.
 #include <xenon/xml_parser_base.h>
+#include <ict/osstream.h>
 
 #include <stack>
 #include <map>
@@ -12,11 +13,12 @@ namespace xenon {
     class XmlText
     {
         public:
-        XmlText(std::string const & s) : content(s) { }
+        explicit XmlText(std::string const & s) : content(s) { }
         std::string content;
     };
 
-    inline std::ostream & operator<<(std::ostream & os, XmlText const & cd)
+    template <typename S>
+    inline S & to_stream(S & os, XmlText const & cd)
     {
         std::string::const_iterator it;
         for (it=cd.content.begin(); it!= cd.content.end(); ++it)
@@ -35,6 +37,16 @@ namespace xenon {
         return os;
     }
 
+    template <typename S>
+    inline S & operator<<(S & os, XmlText const & cd) {
+        return to_stream(os, cd);
+    }
+
+    inline ict::osstream & operator<<(ict::osstream & os, XmlText const & cd) {
+        return to_stream(os, cd);
+    }
+
+
     typedef std::pair<std::string, std::string> attpair;
 
     class XmlAttribute
@@ -45,7 +57,7 @@ namespace xenon {
     };
 
     template <typename S>
-    inline S & operator<<(S & os, XmlAttribute const & cd) {
+    inline S & to_stream(S & os, XmlAttribute const & cd) {
         for (auto it=cd.content.begin(); it!= cd.content.end(); ++it)
         {
             switch (*it)
@@ -60,6 +72,14 @@ namespace xenon {
             }
         }
         return os;
+    }
+    template <typename S>
+    inline S & operator<<(S & os, XmlAttribute const & cd) {
+        return to_stream(os, cd);
+    }
+
+    inline ict::osstream & operator<<(ict::osstream & os, XmlAttribute const & cd) {
+        return to_stream(os, cd);
     }
 
     template <typename Stream>
@@ -151,7 +171,7 @@ namespace xenon {
                 //std::sort(attvec.begin(), attvec.end(), AttCompare());
                 my_sort(attvec);
 
-                std::ostringstream os;
+                ict::osstream os;
 
                 std::vector<attpair>::iterator it;
                 for (it=attvec.begin(); it!=attvec.end(); ++it)
@@ -215,10 +235,17 @@ namespace xenon {
 
         std::string str()
         {
-            std::ostringstream ss;
+            ict::osstream ss;
             str(ss);
             return ss.str();
         }
+
+        template <typename S>
+        void to_stream(S & os) {
+            str(os);
+        }
+
+        
 
         std::string raw()
         {
@@ -363,5 +390,5 @@ public:
         std::stack<std::shared_ptr<XmlElement>> elements;
     };
 
-    using xml_type = Xml<std::ostream>;
+    using xml_type = Xml<ict::osstream>;
 }

--- a/include/xenon/xenon.h
+++ b/include/xenon/xenon.h
@@ -6,6 +6,7 @@
 #include <xenon/recref.h>
 #include <xenon/message.h>
 #include <xenon/spec_server.h>
+#include <ict/bitstring.h>
 namespace xenon {
 inline ict::bitstring serialize(const message & m) {
     ict::obitstream bs;
@@ -15,18 +16,10 @@ inline ict::bitstring serialize(const message & m) {
     return bs.bits();
 }
 
-inline ict::bitstring random_bitstring(size_t bit_len) {
-    std::random_device engine;
-    auto bytes = bit_len / 8 + 1;
-    auto v = std::vector<unsigned char>(bytes);
-    for (auto & b : v) b = engine();
-    return ict::bitstring(v.begin(), bit_len);
-}
-
 template <typename Message>
 inline void recombobulate(Message & a) {
     ict::recurse(a.root(), [&](message::cursor c, message::cursor) {
-        if (c->is_pof()) c->bits = random_bitstring(c->bits.bit_size());
+        if (c->is_pof()) c->bits = ict::random_bitstring(c->bits.bit_size());
     });
 }
 

--- a/include/xenon/ximsi.h
+++ b/include/xenon/ximsi.h
@@ -28,7 +28,7 @@ namespace util {
 
         auto nvar = ict::netvar<uint16_t>(D);
 
-        auto bs = bitstring((const char *) nvar.data.data(), 16);
+        auto bs = bitstring(bit_iterator(nvar.data.data()), 16);
         bs.remove(0, 6); 
 
         return bs;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,13 +5,14 @@ include_directories(lua-5.1.4/src)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/o) 
 
 add_custom_command(
-    OUTPUT ${CMAKE_SOURCE_DIR}/include/xenon/xddl.h
-    COMMAND xspx -H t ${CMAKE_CURRENT_SOURCE_DIR}/xddl.xspx
+    OUTPUT ${CMAKE_SOURCE_DIR}/include/xenon/xddl.h ${CMAKE_SOURCE_DIR}/src/xddl_impl.cpp
+    COMMAND xspx -H t -S xddl_impl.cpp  ${CMAKE_CURRENT_SOURCE_DIR}/xddl.xspx
     COMMAND ${CMAKE_COMMAND} -E copy_if_different t ${CMAKE_SOURCE_DIR}/include/xenon/xddl.h
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different xddl_impl.cpp ${CMAKE_SOURCE_DIR}/src/xddl_impl.cpp
     DEPENDS xspx
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/xddl.xspx
     VERBATIM)
 
-add_library(xenon ${CMAKE_SOURCE_DIR}/include/xenon/xddl.h lua-5.1.4/src/lua_all.cpp xml_parser_base.cpp message.cpp xddl.cpp)
+add_library(xenon ${CMAKE_SOURCE_DIR}/include/xenon/xddl.h lua-5.1.4/src/lua_all.cpp xml_parser_base.cpp message.cpp xddl.cpp xddl_impl.cpp)
 
 set_target_properties(xenon PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/o)
 
 add_custom_command(
     OUTPUT ${CMAKE_SOURCE_DIR}/include/xenon/xddl.h
-    COMMAND xspx ${CMAKE_CURRENT_SOURCE_DIR}/xddl.xspx > t
+    COMMAND xspx -H t ${CMAKE_CURRENT_SOURCE_DIR}/xddl.xspx
     COMMAND ${CMAKE_COMMAND} -E copy_if_different t ${CMAKE_SOURCE_DIR}/include/xenon/xddl.h
     DEPENDS xspx
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/xddl.xspx

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -225,5 +225,121 @@ std::string to_text(const message & m, const std::string & format,
     return os.take();
 }
 
+message::cursor create_global(spec::cursor xddl_root, message::cursor globs, const std::string & name, 
+    bitstring bits) {
+    static auto prop_path = path("export/prop");
+    auto root = xddl_root;
+    auto c = find(root, prop_path, tag_of, cmp_name(name));
+
+    if (c == root.end()) { // must be an extern
+        c = find(root, "extern", tag_of, cmp_name(name));
+        if (c == root.end()) IT_PANIC("internal panic looking for " << name  << " in " << xddl_root->parser->file); 
+    }
+
+    if (bits.empty()) {
+        if (auto prop_elem = get_ptr<prop>(c->v)) {
+            if (!prop_elem) IT_PANIC("internal panic");
+            auto v = prop_elem->value.value(leaf(globs));
+            bits = ict::from_integer(v);
+        } 
+    }
+
+    return globs.emplace(node::prop_node, c, bits);
+}
+
+message::cursor set_global(spec::cursor self, message::cursor value) {
+    auto globs = ict::get_root(value).begin(); 
+    auto g = find(globs, value->name());
+    if (g == globs.end()) g = create_global(get_root(self).begin(), globs, value->name(), value->bits);
+    else g->bits = value->bits;
+    return g;
+}
+
+spec::cursor get_variable(const std::string & name, spec::cursor context) {
+    static auto prop_path = path("xddl/export/prop");
+    static auto extern_path = path("xddl/extern");
+    spec::ascending_cursor first(context);
+    while (!first.is_root()) {
+        if (name == first->name()) return first;
+        ++first;
+    }
+    auto root = spec::cursor(first);
+    auto x = find(root, prop_path, tag_of, cmp_name(name));
+    if (x != root.end()) return x;
+
+    // not found, search for <extern>
+    // TODO: remove <extern> and just use global, if 2 globals have different defaults, then undefined
+    // or get rid of global and just use props
+    auto c = find(root, extern_path, tag_of, cmp_name(name));
+    if (c != root.end()) return c;
+    
+    // verify(root);
+    IT_PANIC("cannot find " << name << " starting at " << context->name());
+}
+
+// parse time
+message::cursor get_variable(const std::string & name, message::cursor context) {
+    auto first = rfind(context, name);
+    if (!first.is_root()) return first;
+
+    // first is now pointing at message root
+    auto globs = first.begin();
+    auto g = find(globs, name);
+    if (g == globs.end()) {
+        auto xddl_root = ict::get_root(context->elem).begin();
+        try {
+            g = create_global(xddl_root, globs, name);
+        } catch (std::exception & e) {
+            ict::osstream os;
+            os << e.what() << " [" << context->file() << ":" << context->line() << "]";
+            IT_FATAL(os.str());
+        }
+    }
+    return g;
+}
+
+int64_t eval_variable_list(const std::string &first, const std::string &second, spec::cursor context) {
+    auto f = get_variable(first, context);
+    auto s = find(f, second);
+    if (s == f.end()) { // second not found, it may be in another spec though (f may be a reclink)
+        // f is a reclink, so get the record it is pointing to.
+        if (auto r = get_ptr<reclink>(f->v)) {
+            auto xddl = rfind(context, "xddl", tag_of);
+            auto c = find(xddl, "record", tag_of, [&](const element &e) {
+                if (auto rec = get_ptr<recdef>(e.v)) {
+                    if (rec->id == r->href) return 1;
+                }
+                return 0;
+            });
+            if (c == xddl.end()) IT_PANIC("cannot find record: " << r->href);
+            s = find(c, second);
+            if (s == c.end()) IT_PANIC("cannot find " << second << " in " << r->href);
+        }
+    }
+    s->flags.set(element::dependent_flag);
+    return 1;
+}
+
+int64_t eval_function(const std::string &name, message::cursor context,  
+    const std::vector<ict::expression::param_type> &params) {
+    if (name == "sizeof") {
+        auto c = get_variable(params[0].name, context);
+        return bit_size(c);
+    }
+    else if ((name == "defined")) {
+        if (rfind(context, params[0].name).is_root()) return 0;
+        return 1;
+    }
+
+    else if ((name == "value")) {
+        auto c = rfind(context, params[0].name);
+        if (!c.is_root()) return c->value();
+        IT_WARN("cannot find " << params[0].name);
+        return 0;
+    }
+
+    IT_PANIC("runtime eval_function not implemented for " << name);
+}
+
 } // namespace
 

--- a/src/xddl.cpp
+++ b/src/xddl.cpp
@@ -807,5 +807,4 @@ void prop::vto_html(spec::const_cursor self, std::ostream & os) const {
 void type::vto_html(spec::const_cursor self, std::ostream & os) const {
     os << self->name();
 }
-
 } // namespace

--- a/src/xddl.xspx
+++ b/src/xddl.xspx
@@ -7,6 +7,7 @@
     <!-- declare types used by attributes. -->
     <type cpp="bool" def="false">bool</type>
     <type cpp="int64_t" def="0">integer</type>
+
     <type cpp="size_t" def="1">pos_integer</type>
     <type cpp="size_t" def="0">size</type>
     <type cpp="std::string">string</type>

--- a/tools/idm/idm.cpp
+++ b/tools/idm/idm.cpp
@@ -97,13 +97,8 @@ void processXddlFile(ict::command const & line, command_flags const & flags) {
             inst = xenon::parse(start, bs);
             if (flags.flat_xml) inst_dump << xenon::to_xml(inst, filter) << '\n';
             else if (flags.pretty_xml) {
-#if 1
                 xenon::xml_type pretty(xenon::to_xml(inst, filter));
                 inst_dump << pretty.str();
-#else
-                pretty << xenon::to_xml(inst, filter) << "\n";
-                inst_dump << pretty;
-#endif
             }
             else if (flags.debug_print) {
                 inst_dump << xenon::to_debug_text(inst, filter) << '\n';

--- a/tools/xspx/xspx.cpp
+++ b/tools/xspx/xspx.cpp
@@ -9,11 +9,19 @@
 int main(int argc, char **argv) {
 
     try {
+        std::string hfile;
+        std::string sfile;
         bool dispatch = false;
         std::string dispatch_name = "dispatch";
         xsp_parser p;
 
         ict::command line("xsp", "Xspec Processor", "xsp [options] xspec-file");
+        line.add(ict::option("header file", 'H', "Output header file", "", [&](std::string s){
+            hfile = s;
+        }));
+        line.add(ict::option("source file", 'S', "Output cpp file", "", [&](std::string s){
+            sfile = s;
+        }));
         line.add(ict::option("dispatcher", 'd', "Generate displatch function", dispatch_name, [&](std::string s){ 
             dispatch = true;
             dispatch_name = s; } ));
@@ -25,7 +33,14 @@ int main(int argc, char **argv) {
         p.open(line.targets[0]);
 
         if (dispatch) xspx::to_dispatch(std::cout, p, dispatch_name);
-        else std::cout << p.header();
+        else {
+            if (!hfile.empty()) {
+                std::ofstream s(hfile, std::ios::out | std::ios::binary);
+                s << p.header();
+            } else {
+                std::cout << p.header();
+            }
+        }
 
     } catch (std::exception & e) {
         std::cerr << e.what() << std::endl;

--- a/tools/xspx/xspx.cpp
+++ b/tools/xspx/xspx.cpp
@@ -33,13 +33,16 @@ int main(int argc, char **argv) {
         p.open(line.targets[0]);
 
         if (dispatch) xspx::to_dispatch(std::cout, p, dispatch_name);
-        else {
-            if (!hfile.empty()) {
-                std::ofstream s(hfile, std::ios::out | std::ios::binary);
-                s << p.header();
-            } else {
-                std::cout << p.header();
-            }
+        else if (!hfile.empty() && !sfile.empty()) {
+                std::ofstream h(hfile, std::ios::out | std::ios::binary);
+                std::ofstream s(sfile, std::ios::out | std::ios::binary);
+                p.to_stream(h, s);
+
+        } else if (!hfile.empty()) {
+            std::ofstream h(hfile, std::ios::out | std::ios::binary);
+            p.to_stream(h);
+        } else {
+            p.to_stream(std::cout);
         }
 
     } catch (std::exception & e) {

--- a/tools/xspx/xspx.cpp
+++ b/tools/xspx/xspx.cpp
@@ -29,6 +29,7 @@ int main(int argc, char **argv) {
         line.parse(argc, argv);
 
         if (line.targets.size() != 1) IT_FATAL("exactly one xspec-file must be specified");
+        if (hfile.empty() && !sfile.empty()) IT_FATAL("header file must also be specified");
 
         p.open(line.targets[0]);
 

--- a/tools/xspx/xspx_parser.cpp
+++ b/tools/xspx/xspx_parser.cpp
@@ -268,8 +268,10 @@ void xsp_parser::to_stream(std::ostream & h, std::ostream & s) const {
 
     std::ostringstream os;
     xenon::cpp_code code;
-    os << "#include <xenon/xddl.h>";
+    os << "#include <xenon/xenon.h>";
+    os << "namespace xenon {";
     parser_const(os, st::source_impl);
+    os << "}";
     code.add(os.str());
     s << code.str();
 }
@@ -464,7 +466,7 @@ void xsp_parser::const_content(std::ostream & os) const {
 void xsp_parser::parser_const(std::ostream & os, st::type t) const {
     switch (t) {
         case st::header_decl :
-            os << class_name << "()";
+            os << class_name << "();";
             break;
         case st::header_impl : 
             os << class_name << "()";

--- a/tools/xspx/xspx_parser.cpp
+++ b/tools/xspx/xspx_parser.cpp
@@ -229,13 +229,7 @@ void generate_uid_constants(S & os, T first, T last) {
     });
 }
 
-#if 0
-std::string xsp_parser::source() const {
-    return "";
-}
-#endif
-
-std::string xsp_parser::header() const  {
+void xsp_parser::header(std::ostream & h, st::type t) const  {
     std::ostringstream os;
     os << "#pragma once //\n";
     os << code_seg(code_refs, "head");
@@ -256,13 +250,28 @@ std::string xsp_parser::header() const  {
 
     os << "}";
     
-    os << parser_impl();
+    os << parser_impl(t);
 
     os << code_seg(code_refs, "tail");
 
     xenon::cpp_code code;
     code.add(os.str());
-    return code.str();
+    h << code.str();
+}
+
+void xsp_parser::to_stream(std::ostream & h) const {
+    header(h, st::header_impl);
+}
+
+void xsp_parser::to_stream(std::ostream & h, std::ostream & s) const {
+    header(h, st::header_decl);
+
+    std::ostringstream os;
+    xenon::cpp_code code;
+    os << "#include <xenon/xddl.h>";
+    parser_const(os, st::source_impl);
+    code.add(os.str());
+    s << code.str();
 }
 
 std::ostream& xsp_parser::to_decl(std::ostream& os, const elem_type & elem, const std::string & root) const {
@@ -435,21 +444,8 @@ std::string xsp_parser::parser_header() const {
     return os.str();
 }
 
-#if 0
-std::string xsp_parser::constuctor() const {
-}
-#endif
-
-std::string xsp_parser::parser_impl() const {
-    std::ostringstream os;
-    os << 
-    "#include <xenon/xml_parser.h>\n" <<
-    head <<
-    "namespace " << name_space << " {"
-    "struct " << class_name  << " {"
-        "public:" <<
-            class_name << "() {";
-
+void xsp_parser::const_content(std::ostream & os) const {
+    os << "{ ";
     os << "parents.push_back(ast.root());";
     os << "p.root_tag(" << qt(root) << ");";
 
@@ -464,7 +460,32 @@ std::string xsp_parser::parser_impl() const {
     for (const auto & choice : choices) to_choice_init(os, choice);
 
     os << "}";
+}
+void xsp_parser::parser_const(std::ostream & os, st::type t) const {
+    switch (t) {
+        case st::header_decl :
+            os << class_name << "()";
+            break;
+        case st::header_impl : 
+            os << class_name << "()";
+            const_content(os);
+            break;
+        case st::source_impl : 
+            os << class_name << "::" << class_name << "()";
+            const_content(os);
+    }
+}
 
+std::string xsp_parser::parser_impl(st::type t) const {
+    std::ostringstream os;
+    os << 
+    "#include <xenon/xml_parser.h>\n" <<
+    head <<
+    "namespace " << name_space << " {"
+    "struct " << class_name  << " {"
+        "public:";
+
+    parser_const(os, t);
     os << class_name << "(const std::string & filename) : " << class_name << "() {"  << 
         "file = filename; p.open(filename); }";
 

--- a/tools/xspx/xspx_parser.cpp
+++ b/tools/xspx/xspx_parser.cpp
@@ -229,6 +229,12 @@ void generate_uid_constants(S & os, T first, T last) {
     });
 }
 
+#if 0
+std::string xsp_parser::source() const {
+    return "";
+}
+#endif
+
 std::string xsp_parser::header() const  {
     std::ostringstream os;
     os << "#pragma once //\n";
@@ -428,6 +434,11 @@ std::string xsp_parser::parser_header() const {
     "#include \"xddl.h\"";
     return os.str();
 }
+
+#if 0
+std::string xsp_parser::constuctor() const {
+}
+#endif
 
 std::string xsp_parser::parser_impl() const {
     std::ostringstream os;

--- a/tools/xspx/xspx_parser.h
+++ b/tools/xspx/xspx_parser.h
@@ -157,6 +157,13 @@ inline std::ostream& add_children(std::ostream & os, const T & elem) {
 
 elem_type merge_elems(const elem_type & a, const elem_type & b);
 
+namespace st { // source type
+enum type {
+    header_decl,
+    header_impl,
+    source_impl
+};
+}
 
 class xsp_parser {
     public:
@@ -167,9 +174,15 @@ class xsp_parser {
     }
 
     void parser_destructor(std::ostream & os) const;
-    std::string header() const;
+
+    void to_stream(std::ostream & h) const;
+    void to_stream(std::ostream & h, std::ostream & s) const;
+
+    void header(std::ostream &, st::type) const;
     std::string parser_header() const;
-    std::string parser_impl() const;
+    std::string parser_impl(st::type) const;
+    void const_content(std::ostream & os) const;
+    void parser_const(std::ostream & os, st::type t = st::header_impl) const;
 
     std::ostream& to_init(std::ostream& os, const elem_type & elem) const;
     std::ostream& to_decl(std::ostream& os, const elem_type & elem, const std::string & root) const;


### PR DESCRIPTION
## Almost 3X Improvement in  Compile Time!

Moved several functions that were defined in header files into the library.  I updated the code generator that parses XDDL to also create a source file.  I placed the code for spec loading, which was heavily laden with lambda functions, into the source file.

My performance analysis resulted in about a 2.7 times faster compilation of the tools and examples that used the `xenon` library.

## Improved Bitstring API

Added `bit_iterator` to `bitstring` and updated its API to use it.  This simplified things.  If you were using one of the weird bitstring constructors then you may have a compiler error, otherwise things should work the same.  See <https://github.com/intrig/ict/pull/6> for details.
