### PR TITLE
fix redirect error

### DIFF
--- a/tools/asnx/asn1.ypp
+++ b/tools/asnx/asn1.ypp
@@ -963,6 +963,7 @@ int main(int argc, char **argv) {
     ict::command line("asnx", "Convert asn.1 to xddl",
                       "asnx [options] asn_file ...");
 
+    std::streambuf *coutbuf = std::cout.rdbuf();
     try {
         line.add(ict::Option("comments", 'c',
                              "Do not print header comment in resulting xddl",
@@ -1009,4 +1010,5 @@ int main(int argc, char **argv) {
         cerr << filename << ": " << e.what() << endl;
         return 1;
     }
+    std::cout.rdbuf(coutbuf);
 }

--- a/tools/xmlpatch.cpp
+++ b/tools/xmlpatch.cpp
@@ -107,6 +107,7 @@ class XmlSource {
 };
 
 int main(int argc, char **argv) {
+    std::streambuf *coutbuf = std::cout.rdbuf();
     try {
         std::string ofile;
         ict::command line("xml-patch", "Patch up an xml file",
@@ -138,4 +139,5 @@ int main(int argc, char **argv) {
         cerr << e.what() << endl;
         return 1;
     }
+    std::cout.rdbuf(coutbuf);
 }


### PR DESCRIPTION
It's important to restore cout before exit otherwise some implementations crash.  There should be an RAII object for this.