### PR TITLE
bit_iterator is moved back to ict::

### DIFF
--- a/include/xenon/ximsi.h
+++ b/include/xenon/ximsi.h
@@ -21,7 +21,7 @@ bitstring encode_three(std::string &source, int start_index) {
 
     auto nvar = ict::netvar<uint16_t>(D);
 
-    auto bs = bitstring(bitstring::bit_iterator(nvar.data.data()), 16);
+    auto bs = bitstring(bit_iterator(nvar.data.data()), 16);
     bs.remove(0, 6);
 
     return bs;


### PR DESCRIPTION
It was moved inside bitstring.

Signed-off-by: Mark Beckwith <wythe@intrig.com>